### PR TITLE
Staggered thread start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+all: pretty lint
+
+lint:
+	./node_modules/.bin/eslint lib/*
+
+pretty:
+	./node_modules/.bin/prettier --write lib/*

--- a/lib/main.js
+++ b/lib/main.js
@@ -70,37 +70,34 @@ if (argv._[0] === "record") {
   console.error(`Listening on port ${argv.port}`);
   record.start(host, port, argv.port);
 } else if (argv._[0] === "playback") {
+  startPlayback(argv.file, argv.concurrency, argv.nruns, argv.target)
+    .then(() => {
+      process.exit(0);
+    })
+    .catch(err => {
+      console.error("Error: ", err);
+    });
+}
+
+async function startPlayback(file, concurrency, nruns, target) {
   const reporter = new Reporter();
   process.on("SIGINT", () => {
     reporter.dump();
     process.exit(1);
   });
-  readLines(argv.file)
-    .then(parseJSON)
-    .then(jsonEvents => {
-      const plays = [];
-      for (let i = 0; i < argv.concurrency; i++) {
-        const startDelayMs = i * argv.startDelayMs;
-        plays.push(
-          run(jsonEvents, startDelayMs, i, argv.nruns, reporter, argv.target)
-        );
-      }
 
-      return Promise.all(plays).then(
-        () => {
-          reporter.dump();
-          //process.exit(0);
-        },
-        err => {
-          console.error("Error: ", err);
-          process.exit(1);
-        }
-      );
-    })
-    .catch(err => {
-      console.error("Error: ", err);
-      process.exit(1);
-    });
+  const lines = await readLines(argv.file);
+  const jsonEvents = parseJSON(lines);
+  const plays = [];
+  for (let i = 0; i < argv.concurrency; i++) {
+    const startDelayMs = i * argv.startDelayMs;
+    plays.push(
+      run(jsonEvents, startDelayMs, i, argv.nruns, reporter, argv.target)
+    );
+  }
+
+  await Promise.all(plays);
+  reporter.dump();
 }
 
 async function sleep(ms) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -119,14 +119,8 @@ async function run(
     const destfile = path.join(argv.outdir, `profile_${threadId}_${i}.txt`);
     const outStream = await createWriteStreamAsync(destfile);
     const job = reporter.createJob(outStream);
-    try {
-      // console.log(`running ${threadId}_${i}`);
-      await playback(jsonEvents, job, target);
-      // job.success();
-    } catch (err) {
-      job.failure(err);
-      // throw err;
-    }
+    // playback() is guaranteed not to throw
+    await playback(jsonEvents, job, target);
   }
 }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 const path = require("path");
 
 require("longjohn");
+const byline = require("byline");
 
 const playback = require("./playback");
 const record = require("./record");
@@ -69,37 +70,65 @@ if (argv._[0] === "record") {
     reporter.dump();
     process.exit(1);
   });
-  const plays = [];
-  for (let i = 0; i < argv.concurrency; i++) {
-    plays.push(run(argv.file, i, argv.nruns, reporter, argv.target));
-  }
+  readLines(argv.file)
+    .then(parseJSON)
+    .then(jsonEvents => {
+      const plays = [];
+      for (let i = 0; i < argv.concurrency; i++) {
+        plays.push(run(jsonEvents, i, argv.nruns, reporter, argv.target));
+      }
 
-  Promise.all(plays).then(
-    () => {
-      reporter.dump();
-      //process.exit(0);
-    },
-    err => {
+      return Promise.all(plays).then(
+        () => {
+          reporter.dump();
+          //process.exit(0);
+        },
+        err => {
+          console.error("Error: ", err);
+          process.exit(1);
+        }
+      );
+    })
+    .catch(err => {
       console.error("Error: ", err);
       process.exit(1);
-    }
-  );
+    });
 }
 
-async function run(file, threadId, times, reporter, target) {
+async function run(jsonEvents, threadId, times, reporter, target) {
   for (let i = 0; i < times; i++) {
     const destfile = path.join(argv.outdir, `profile_${threadId}_${i}.txt`);
     const outStream = await createWriteStreamAsync(destfile);
     const job = reporter.createJob(outStream);
     try {
       // console.log(`running ${threadId}_${i}`);
-      await playback(file, job, target);
-      job.success();
+      await playback(jsonEvents, job, target);
+      // job.success();
     } catch (err) {
       job.failure(err);
-      throw err;
+      // throw err;
     }
   }
+}
+
+async function readLines(file) {
+  const lineReader = byline(fs.createReadStream(file)),
+        lines = [];
+
+  lineReader.on("data", line => {
+    lines.push(line);
+  });
+
+  return new Promise((resolve, reject) => {
+    lineReader.on("end", () => {
+      resolve(lines);
+    });
+    lineReader.on("error", reject);
+  });
+}
+
+function parseJSON(lines) {
+  return lines.map(JSON.parse);
 }
 
 function createWriteStreamAsync(path, options) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -80,8 +80,10 @@ if (argv._[0] === "record") {
     .then(jsonEvents => {
       const plays = [];
       for (let i = 0; i < argv.concurrency; i++) {
-        const startDelayMs = i*argv.startDelayMs;
-        plays.push(run(jsonEvents, startDelayMs, i, argv.nruns, reporter, argv.target));
+        const startDelayMs = i * argv.startDelayMs;
+        plays.push(
+          run(jsonEvents, startDelayMs, i, argv.nruns, reporter, argv.target)
+        );
       }
 
       return Promise.all(plays).then(
@@ -107,7 +109,14 @@ async function sleep(ms) {
   });
 }
 
-async function run(jsonEvents, startDelayMs, threadId, times, reporter, target) {
+async function run(
+  jsonEvents,
+  startDelayMs,
+  threadId,
+  times,
+  reporter,
+  target
+) {
   await sleep(startDelayMs);
   for (let i = 0; i < times; i++) {
     const destfile = path.join(argv.outdir, `profile_${threadId}_${i}.txt`);
@@ -126,7 +135,7 @@ async function run(jsonEvents, startDelayMs, threadId, times, reporter, target) 
 
 async function readLines(file) {
   const lineReader = byline(fs.createReadStream(file)),
-        lines = [];
+    lines = [];
 
   lineReader.on("data", line => {
     lines.push(line);

--- a/lib/main.js
+++ b/lib/main.js
@@ -37,6 +37,11 @@ const argv = require("yargs")
       describe: "Number of runs per thread",
       default: 1
     });
+    yargs.options("startDelayMs", {
+      alias: "s",
+      describe: "Number of milliseconds to wait between starting threads",
+      default: 0
+    });
     yargs.options("outdir", {
       alias: "o",
       describe: "The directory to write profiles to",
@@ -75,7 +80,8 @@ if (argv._[0] === "record") {
     .then(jsonEvents => {
       const plays = [];
       for (let i = 0; i < argv.concurrency; i++) {
-        plays.push(run(jsonEvents, i, argv.nruns, reporter, argv.target));
+        const startDelayMs = i*argv.startDelayMs;
+        plays.push(run(jsonEvents, startDelayMs, i, argv.nruns, reporter, argv.target));
       }
 
       return Promise.all(plays).then(
@@ -95,7 +101,14 @@ if (argv._[0] === "record") {
     });
 }
 
-async function run(jsonEvents, threadId, times, reporter, target) {
+async function sleep(ms) {
+  return new Promise((resolve, reject) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function run(jsonEvents, startDelayMs, threadId, times, reporter, target) {
+  await sleep(startDelayMs);
   for (let i = 0; i < times; i++) {
     const destfile = path.join(argv.outdir, `profile_${threadId}_${i}.txt`);
     const outStream = await createWriteStreamAsync(destfile);

--- a/lib/playback.js
+++ b/lib/playback.js
@@ -1,4 +1,3 @@
-const fs = require("fs");
 const evt = require("./shiny-events");
 
 async function playback(jsonEvents, reporter, target) {

--- a/lib/playback.js
+++ b/lib/playback.js
@@ -1,41 +1,24 @@
-const byline = require("byline");
 const fs = require("fs");
 const evt = require("./shiny-events");
 
-async function playback(file, reporter, target) {
-  let tail = new Promise((resolve, reject) => {
-    resolve();
-  });
-
+async function playback(jsonEvents, reporter, target) {
   const ctx = new evt.EventContext(target);
 
-  const lines = byline(fs.createReadStream(file));
-
-  return new Promise((resolve, reject) => {
-    lines.on("data", async line => {
-      const obj = JSON.parse(line);
-      const shinyEvent = evt.fromJSON(obj);
-      tail = tail.then(async () => {
-        reporter.beginStep(shinyEvent);
-        try {
-          return await shinyEvent.execute(ctx);
-        } finally {
-          reporter.endStep(shinyEvent);
-        }
-      });
-    });
-    lines.on("end", async () => {
+  try {
+    for (let i = 0; i < jsonEvents.length; i++) {
+      const shinyEvent = evt.fromJSON(jsonEvents[i]);
+      reporter.beginStep(shinyEvent);
       try {
-        await tail;
-        reporter.success();
-      } catch (err) {
-        reporter.failure(err);
+        await shinyEvent.execute(ctx);
       } finally {
-        // Clean up
-        ctx.close();
-        resolve();
+        reporter.endStep(shinyEvent);
       }
-    });
-  });
+    }
+    reporter.success();
+  } catch (err) {
+    reporter.failure(err);
+  } finally {
+    ctx.close();
+  }
 }
 module.exports = playback;

--- a/lib/shiny-events.js
+++ b/lib/shiny-events.js
@@ -68,7 +68,7 @@ class EventContext extends EventEmitter {
   }
 
   resolve(url) {
-    return this.target  + url;
+    return this.target + url;
   }
 }
 exports.EventContext = EventContext;


### PR DESCRIPTION
Adds two features:

1. JSON was being parsed for every run, that's actually a nontrivial expense. Now JSON is parsed before any threads are launched, and the parsed JSON objects are sent through to the jobs. Note that `events.fromJSON(obj)` is still run every time, I wasn't sure if the event objects get mutated during execution but if we are sure they're not then we can also move the `events.fromJSON` call to the beginning.
2. Added `--startDelayMs` or `-s` to specify number of milliseconds to delay between launching threads. @alandipert and I couldn't decide on a default so we left it at 0.