### PR TITLE
Pause before each websocket send, and some requests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,7 @@
   },
   "extends": "eslint:recommended",
   "rules": {
-    "indent": ["error", 2],
+    "indent": ["off"],
     "linebreak-style": ["error", "unix"],
     "quotes": ["error", "double"],
     "semi": ["error", "always"],

--- a/lib/main.js
+++ b/lib/main.js
@@ -5,6 +5,7 @@ const url = require("url");
 const byline = require("byline");
 require("longjohn");
 
+const misc = require("./misc");
 const playback = require("./playback");
 const record = require("./record");
 const Reporter = require("./reporter");
@@ -48,6 +49,13 @@ const argv = require("yargs")
       describe: "The directory to write profiles to",
       default: "./profiles"
     });
+    yargs.options("pause-mode", {
+      alias: "p",
+      describe:
+        "Whether to pause when the original recording paused. " +
+        "Either 'exact' (yes) or 'none' (no).",
+      default: "exact"
+    });
   })
   .demandCommand(1, "Please specify a command")
   .help().argv;
@@ -86,24 +94,16 @@ async function startPlayback(file, concurrency, nruns, target) {
     process.exit(1);
   });
 
-  const lines = await readLines(argv.file);
+  const lines = await readLines(file);
   const jsonEvents = parseJSON(lines);
   const plays = [];
-  for (let i = 0; i < argv.concurrency; i++) {
+  for (let i = 0; i < concurrency; i++) {
     const startDelayMs = i * argv.startDelayMs;
-    plays.push(
-      run(jsonEvents, startDelayMs, i, argv.nruns, reporter, argv.target)
-    );
+    plays.push(run(jsonEvents, startDelayMs, i, nruns, reporter, target));
   }
 
   await Promise.all(plays);
   reporter.dump();
-}
-
-async function sleep(ms) {
-  return new Promise((resolve, reject) => {
-    setTimeout(resolve, ms);
-  });
 }
 
 async function run(
@@ -114,13 +114,13 @@ async function run(
   reporter,
   target
 ) {
-  await sleep(startDelayMs);
+  await misc.sleep(startDelayMs);
   for (let i = 0; i < times; i++) {
     const destfile = path.join(argv.outdir, `profile_${threadId}_${i}.txt`);
     const outStream = await createWriteStreamAsync(destfile);
     const job = reporter.createJob(outStream);
     // playback() is guaranteed not to throw
-    await playback(jsonEvents, job, target);
+    await playback(jsonEvents, job, target, argv["pause-mode"]);
   }
 }
 
@@ -141,7 +141,8 @@ async function readLines(file) {
 }
 
 function parseJSON(lines) {
-  return lines.map(JSON.parse);
+  // Filter out comments first
+  return lines.filter(line => !/^#/.test(line)).map(JSON.parse);
 }
 
 function createWriteStreamAsync(path, options) {

--- a/lib/misc.js
+++ b/lib/misc.js
@@ -1,0 +1,6 @@
+async function sleep(ms) {
+  return new Promise((resolve, reject) => {
+    setTimeout(resolve, ms);
+  });
+}
+exports.sleep = sleep;

--- a/lib/playback.js
+++ b/lib/playback.js
@@ -1,17 +1,40 @@
 const evt = require("./shiny-events");
 
-async function playback(jsonEvents, reporter, target) {
+const misc = require("./misc");
+
+// pauseMode: "exact" or "none". This list should be extended if we add
+//   randomized sleep times in the future.
+async function playback(jsonEvents, reporter, target, pauseMode = "exact") {
   const ctx = new evt.EventContext(target);
 
   try {
+    let prevEvent = null;
     for (let i = 0; i < jsonEvents.length; i++) {
       const shinyEvent = evt.fromJSON(jsonEvents[i]);
+
+      let sleepTime = shinyEvent.sleepBeforeExecute(ctx, prevEvent);
+      // Additional sleep modes (i.e. randomized) should be added as cases to
+      // this switch, and mutate the sleepTime variable.
+      switch (pauseMode) {
+        case "exact":
+          break;
+        case "none":
+          sleepTime = 0;
+          break;
+        default:
+          throw new Error(`Unknown pause mode '${pauseMode}'`);
+      }
+      if (sleepTime && sleepTime > 0) {
+        await misc.sleep(sleepTime);
+      }
+
       reporter.beginStep(shinyEvent);
       try {
         await shinyEvent.execute(ctx);
       } finally {
-        reporter.endStep(shinyEvent);
+        reporter.endStep(shinyEvent, sleepTime);
       }
+      prevEvent = shinyEvent;
     }
     reporter.success();
   } catch (err) {

--- a/lib/record.js
+++ b/lib/record.js
@@ -53,9 +53,15 @@ class RecordingSession {
 function start(target, listenPort = 8600) {
   const sep = new ShinyEventProxy(target);
 
+  recordComment(`Target: ${target}`);
+
   new RecordingSession(sep);
 
   sep.listen(listenPort);
 }
 
 exports.start = start;
+
+function recordComment(comment) {
+  console.log(comment.replace(/(^|\n)/g, "$1# "));
+}

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -57,7 +57,7 @@ class SubReporter {
     this.currentStepStartTime = new Date();
   }
 
-  endStep(event) {
+  endStep(event, sleepTime) {
     if (!this.currentStep) {
       throw new Error("Can't endStep when no step is in progress");
     }
@@ -73,9 +73,14 @@ class SubReporter {
     this.currentStep = null;
     this.currentStepStartTime = null;
 
-    this.outputStream.write(
-      [this.nextId++, now.toISOString(), elapsed, event.type].join("\t") + "\n"
-    );
+    const row = [
+      this.nextId++,
+      now.toISOString(),
+      elapsed,
+      event.type,
+      sleepTime
+    ];
+    this.outputStream.write(row.join("\t") + "\n");
   }
 
   success() {

--- a/lib/shiny-events.js
+++ b/lib/shiny-events.js
@@ -42,6 +42,11 @@ class EventContext extends EventEmitter {
     });
   }
 
+  isConnected() {
+    // Maybe should be checking readyState too?
+    return this._websocket;
+  }
+
   sendWS(message) {
     this._websocket.sendUTF(message);
   }
@@ -157,6 +162,9 @@ class ShinyEvent {
     if (new.target === ShinyEvent) {
       throw new TypeError("ShinyEvent is an abstract type");
     }
+    if (!(created instanceof Date)) {
+      created = new Date(created);
+    }
     this.type = new.target.type;
     this.created = created;
   }
@@ -165,17 +173,26 @@ class ShinyEvent {
     throw new TypeError("parse() method must be implemented in subclasses");
   }
 
+  sleepBeforeExecute(ctx, prevEvent) {
+    // Implement in subclasses to wait the (returned) number of millis
+    // before executing (simulating user think time), if applicable.
+    // Time spent here does not count toward the event playback elapsed
+    // time.
+    return 0;
+  }
+
   async execute(ctx) {
     throw new TypeError("generate() method must be implemented in subclasses");
   }
 }
 
 class ShinyRequestEvent extends ShinyEvent {
-  constructor(method, url, created = new Date()) {
+  constructor(method, url, created = new Date(), statusCode = 200) {
     super(created);
 
     this.method = method;
     this.url = url;
+    this.statusCode = statusCode;
   }
 
   static fromReq(req) {
@@ -183,7 +200,12 @@ class ShinyRequestEvent extends ShinyEvent {
   }
 
   static fromJSON(obj) {
-    return new ShinyRequestEvent(obj.method, obj.url, obj.created);
+    return new ShinyRequestEvent(
+      obj.method,
+      obj.url,
+      obj.created,
+      obj.statusCode
+    );
   }
 
   toJSON() {
@@ -191,12 +213,20 @@ class ShinyRequestEvent extends ShinyEvent {
       type: this.type,
       created: this.created,
       method: this.method,
-      url: this.url
+      url: this.url,
+      statusCode: this.statusCode
     };
   }
 
   parse(ctx) {
     this.url = ctx.tokens.insertTokenPlaceholders(this.url);
+  }
+
+  sleepBeforeExecute(ctx, prevEvent) {
+    // Requests before websocket connection are assumed to happen as
+    // quickly as possible. Those happening after could be e.g. file
+    // downloads initiated by the user.
+    return ctx.isConnected() ? this.created - prevEvent.created : 0;
   }
 
   async execute(ctx) {
@@ -208,7 +238,7 @@ class ShinyRequestEvent extends ShinyEvent {
     return new Promise((resolve, reject) => {
       const protocol = urlObj.protocol === "https:" ? https : http;
       const req = protocol.request(urlObj, async res => {
-        if (res.statusCode !== 200) {
+        if (res.statusCode !== this.statusCode) {
           const body = await this.handleResponse(ctx, res);
           reject(
             new Error(`Request failed with status ${res.statusCode}:\n${body}`)
@@ -226,6 +256,8 @@ class ShinyRequestEvent extends ShinyEvent {
 
   async handleResponse(ctx, res) {
     const writer = new streams.WritableStream();
+    this.statusCode = res.statusCode;
+
     return new Promise((resolve, reject) => {
       res.on("data", chunk => {
         writer.write(chunk);
@@ -419,6 +451,10 @@ class ShinyWSSendEvent extends ShinyEvent {
     this.message = ctx.tokens.insertTokenPlaceholders(this.message);
   }
 
+  sleepBeforeExecute(ctx, prevEvent) {
+    return this.created - prevEvent.created;
+  }
+
   async execute(ctx) {
     const message = ctx.tokens.replaceTokenPlaceholders(this.message);
     // console.log("WSSEND: " + message);
@@ -526,6 +562,10 @@ class ShinyWSCloseEvent extends ShinyEvent {
 
   parse(ctx) {}
 
+  sleepBeforeExecute(ctx, prevEvent) {
+    return this.created - prevEvent.created;
+  }
+
   async execute(ctx) {
     ctx.closeWS();
   }
@@ -562,6 +602,13 @@ function shouldIgnore(message) {
   const keys = Object.keys(msg);
   if (!keys.find(key => !ignorable.includes(key))) {
     return true;
+  }
+
+  if (keys.length === 1 && keys[0] === "custom") {
+    const customKeys = Object.keys(msg.custom);
+    if (customKeys.length === 1 && customKeys[0] === "reactlog") {
+      return true;
+    }
   }
 
   if (JSON.stringify(msg) === '{"errors":[],"values":[],"inputMessages":[]}') {


### PR DESCRIPTION
This slows down playback to match the "think times" recorded in
the original run. Each websocket-send pauses the same amount of
time that elapsed between its start, and the previous event's
start, in the original run. This may be an oversimplified
heuristic for determining the amount of time to wait. For one
thing, we should probably measure from the previous event's *end*
time, not start time. But we don't record that today.

Regular HTTP requests do not pause, unless they occur after the
websocket connection has been established. I'm assuming that the
requests before WS-open are all related to initial page load, and
the ones afterwards are related to user actions (like clicking a
downloadButton, or paging through a DT table).

Also added a comment to the top of recordings to indicate the
target URL. This is helpful in case you don't bother to use good
filenames for your recording files.

Also, now recording HTTP request response codes, so benign
failures (like 404 on favicon.ico) don't cause the playback to
fail.